### PR TITLE
use Ubuntu "noble" as default version

### DIFF
--- a/.github/workflows/build_docker_images.yml
+++ b/.github/workflows/build_docker_images.yml
@@ -15,7 +15,7 @@ on:
   workflow_dispatch:
 
 env:
-  DEFAULT_UBUNTU_DIST: jammy  # for the default dist, no suffix to tag
+  DEFAULT_UBUNTU_DIST: noble  # for the default dist, no suffix to tag
   DOCKER_CLI_EXPERIMENTAL: enabled
 
 jobs:

--- a/desktop/Dockerfile
+++ b/desktop/Dockerfile
@@ -1,5 +1,5 @@
 
-ARG ubuntu_dist=jammy
+ARG ubuntu_dist=noble
 
 FROM ubuntu:${ubuntu_dist}
 LABEL maintainer="OPENGIS.ch <info@opengis.ch>"

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -18,7 +18,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-ARG ubuntu_dist=jammy
+ARG ubuntu_dist=noble
 
 FROM ubuntu:${ubuntu_dist}
 LABEL maintainer="OPENGIS.ch <info@opengis.ch>"

--- a/server/README.md
+++ b/server/README.md
@@ -7,7 +7,7 @@ They are considered as NOT production ready.
 
 ## General information
 
-The Docker image is built using *Ubuntu 20.04 (focal) and 22.04 (jammy)* and official QGIS DEBs from <https://qgis.org/>.
+The Docker image is built using *Ubuntu 20.04 (focal), 22.04 (jammy) and 24.04 (noble)* and official QGIS DEBs from <https://qgis.org/>.
 It includes *Nginx* and *Xvfb* and can be used as a standalone service (via HTTP TCP port 80) or as *FCGI* backend (via TCP port 9993).
 
 ## Requisites


### PR DESCRIPTION
The new Ubuntu LTS "Noble" has been released: https://ubuntu.com/about/release-cycle
Hence, this docker image should use it as default.