### PR TITLE
Added build config for debian bookworm

### DIFF
--- a/.github/workflows/build_docker_images.yml
+++ b/.github/workflows/build_docker_images.yml
@@ -15,7 +15,7 @@ on:
   workflow_dispatch:
 
 env:
-  DEFAULT_UBUNTU_DIST: noble  # for the default dist, no suffix to tag
+  DEFAULT_UBUNTU_RELEASE: noble  # for the default dist, no suffix to tag
   DOCKER_CLI_EXPERIMENTAL: enabled
 
 jobs:
@@ -69,9 +69,16 @@ jobs:
       fail-fast: false
       matrix:
         qgis_type: ['desktop', 'server']
-        ubuntu_dist: [ 'focal', 'jammy', 'noble' ]
         version: ['stable', 'ltr']
-
+        platform:
+          - os: ubuntu
+            release: focal
+          - os: ubuntu
+            release: jammy
+          - os: ubuntu
+            release: noble
+          - os: debian
+            release: bookworm
 
     steps:
       - uses: actions/checkout@v4
@@ -84,8 +91,8 @@ jobs:
         env: 
           GITHUB_EVENT_NAME: ${{ github.event_name }}
         run : |
-          DOCKER=$(./scripts/get_docker_image_version.py --qgis=${{ matrix.qgis_type }} --dist=${{ matrix.ubuntu_dist }})
-          QGIS=$(./scripts/get_ubuntu_qgis_package_version.py --qgis=${{ matrix.qgis_type }} --dist ${{ matrix.ubuntu_dist }})
+          DOCKER=$(./scripts/get_docker_image_version.py --qgis=${{ matrix.qgis_type }} --dist=${{ matrix.platform.release }})
+          QGIS=$(./scripts/get_ubuntu_qgis_package_version.py --qgis=${{ matrix.qgis_type }} --os=${{ matrix.platform.os }} --dist ${{ matrix.platform.release }})
 
           DOCKER_VERSION=$(echo "${DOCKER}" | jq ".${{ matrix.version }}")
           QGIS_VERSION=$(echo "${QGIS}" | jq ".${{ matrix.version }}")
@@ -133,5 +140,5 @@ jobs:
         env:
           DOCKER_USERNAME: ${{ secrets.docker_username }}
           DOCKER_PASSWORD: ${{ secrets.docker_password }}
-        run: ./scripts/build-push-docker.sh ${{ matrix.qgis_type }} ${{ matrix.version }} ${{steps.determine.outputs.qgis_version}} ${{ matrix.ubuntu_dist }} ${DEFAULT_UBUNTU_DIST}
+        run: ./scripts/build-push-docker.sh ${{ matrix.qgis_type }} ${{ matrix.version }} ${{steps.determine.outputs.qgis_version}} ${{ matrix.platform.os }} ${{ matrix.platform.release }} ${DEFAULT_UBUNTU_RELEASE}
 

--- a/desktop/Dockerfile
+++ b/desktop/Dockerfile
@@ -1,17 +1,16 @@
+ARG os=ubuntu
+ARG release=noble
 
-ARG ubuntu_dist=noble
-
-FROM ubuntu:${ubuntu_dist}
+FROM ${os}:${release}
 LABEL maintainer="OPENGIS.ch <info@opengis.ch>"
 
-
-ARG ubuntu_dist
-ARG repo=ubuntu
+ARG os
+ARG release
 
 RUN apt update && apt install -y gnupg wget software-properties-common && \
     wget -qO - https://qgis.org/downloads/qgis-2022.gpg.key | gpg --no-default-keyring --keyring gnupg-ring:/etc/apt/trusted.gpg.d/qgis-archive.gpg --import && \
     chmod a+r /etc/apt/trusted.gpg.d/qgis-archive.gpg && \
-    add-apt-repository "deb https://qgis.org/${repo} ${ubuntu_dist} main" && \
+    add-apt-repository "deb https://qgis.org/${os} ${release} main" && \
     apt update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y python3-pip qgis python3-qgis python3-qgis-common python3-venv \
       python3-pytest python3-mock xvfb qttools5-dev-tools && \

--- a/scripts/build-push-docker.sh
+++ b/scripts/build-push-docker.sh
@@ -5,15 +5,16 @@ set -e
 QGIS_TYPE=$1
 RELEASE_TYPE=$2
 QGIS_VERSION=$3
-UBUNTU_DIST=$4
-DEFAULT_UBUNTU_DIST=$5
+OS=$4
+OS_RELEASE=$5
+DEFAULT_OS_RELEASE=$6
 
 MAJOR_QGIS_VERSION=$(echo "${QGIS_VERSION}" | cut -d. -f1,2)
 
 if [[ ${RELEASE_TYPE} =~ ^ltr$ ]]; then
-  QGIS_UBUNTU_PPA='ubuntu-ltr'
+  QGIS_PPA="${OS}-ltr"
 else
-  QGIS_UBUNTU_PPA='ubuntu'
+  QGIS_PPA="${OS}"
 fi
 
 if [[ ${QGIS_TYPE} =~ ^server$ ]]; then
@@ -28,12 +29,13 @@ echo "QGIS_TYPE: ${QGIS_TYPE}"
 echo "RELEASE_TYPE: ${RELEASE_TYPE}"
 echo "QGIS_VERSION: ${QGIS_VERSION}"
 echo "MAJOR_QGIS_VERSION: ${MAJOR_QGIS_VERSION}"
-echo "UBUNTU_DIST: ${UBUNTU_DIST}"
-echo "DEFAULT_UBUNTU_DIST: ${DEFAULT_UBUNTU_DIST}"
-echo "QGIS_UBUNTU_PPA: ${QGIS_UBUNTU_PPA}"
+echo "OS: ${OS}"
+echo "OS_RELEASE: ${OS_RELEASE}"
+echo "DEFAULT_OS_RELEASE: ${DEFAULT_OS_RELEASE}"
+echo "QGIS_PPA: ${QGIS_PPA}"
 
-TAGS="${RELEASE_TYPE}-${UBUNTU_DIST} ${MAJOR_QGIS_VERSION}-${UBUNTU_DIST} ${QGIS_VERSION}-${UBUNTU_DIST}"
-if [[ ${UBUNTU_DIST} == ${DEFAULT_UBUNTU_DIST} ]]; then
+TAGS="${RELEASE_TYPE}-${OS_RELEASE} ${MAJOR_QGIS_VERSION}-${OS_RELEASE} ${QGIS_VERSION}-${OS_RELEASE}"
+if [[ ${OS_RELEASE} == ${DEFAULT_OS_RELEASE} ]]; then
   TAGS="${RELEASE_TYPE} ${MAJOR_QGIS_VERSION} ${QGIS_VERSION} ${TAGS}"
 fi
 echo "TAGS: ${TAGS}"
@@ -43,5 +45,5 @@ for TAG in ${TAGS}; do
   ALL_TAGS="${ALL_TAGS} --tag qgis/${REPO}:${TAG}"
 done
 
-docker buildx build --push --platform linux/amd64,linux/arm64 --build-arg ubuntu_dist=${UBUNTU_DIST} --build-arg repo=${QGIS_UBUNTU_PPA}  ${ALL_TAGS} ${QGIS_TYPE}
+docker buildx build --push --platform linux/amd64,linux/arm64 --build-arg os=${OS} --build-arg release=${OS_RELEASE} --build-arg repo=${QGIS_PPA}  ${ALL_TAGS} ${QGIS_TYPE}
 

--- a/scripts/get_docker_image_version.py
+++ b/scripts/get_docker_image_version.py
@@ -11,7 +11,7 @@ import argparse
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument('-q', '--qgis', help='desktop or server', choices=['desktop', 'server'])
-    parser.add_argument('-u', '--dist', help='The Ubuntu distribution')
+    parser.add_argument('-u', '--dist', help='The Ubuntu/Debian distribution')
     #parser.add_argument('-d', '--default-dist', help='The default Ubuntu distribution, for which no suffix is in the tag')
     args = parser.parse_args()
     distro = args.dist

--- a/scripts/get_ubuntu_qgis_package_version.py
+++ b/scripts/get_ubuntu_qgis_package_version.py
@@ -11,8 +11,10 @@ import json
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument('-q', '--qgis', help='desktop or server', choices=['desktop', 'server'])
-    parser.add_argument('-d', '--dist', help='The Ubuntu distribution', default='focal')
+    parser.add_argument('-o', '--os', help='The operating system', choices=['ubuntu', 'debian'], default='ubuntu')
+    parser.add_argument('-d', '--dist', help='The Ubuntu/Debian distribution', default='focal')
     args = parser.parse_args()
+    os = args.os
     dist = args.dist
 
     if args.qgis == 'dekstop':
@@ -22,7 +24,7 @@ if __name__ == "__main__":
 
     data = {}
     for ltr in (True, False):
-        url = 'https://qgis.org/ubuntu{}'.format('-ltr' if ltr else '')
+        url = 'https://qgis.org/{}{}'.format(os, '-ltr' if ltr else '')
         components = ['main']
         repo = APTRepository(url, dist, components)
         package = repo.get_packages_by_name(package_name)[0]


### PR DESCRIPTION
Hi! Our company would like to use debian as a base image for qgis. This PR enables you to also publish a qgis image using debian bookworm.
It would be very nice if you could run review and run this workflow so I can check for errors. I'm not sure if scripts like `scripts/get_docker_image_version.py` are working seamlessly with my changes.