### PR TITLE
add caddy config

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -26,8 +26,11 @@ Containers are not tested on hosts running OSes other than Linux.
 
 ## Services provided
 
-This Docker container exposes HTTP on port `80` via Nginx and a direct FastCGI on port `9993` that can be used directly by an external HTTP proxy (like the provided `docker-compose.yml` does).
-A sample Nginx configuration for using it as a *FastCGI* backend is also [provided](conf/nginx-fcgi-sample.conf).
+This Docker container exposes HTTP on port `80` via Nginx and a direct FastCGI on port `9993` that can be used directly by an external HTTP proxy (like the provided `docker-compose.yml` does).  
+
+The following sample configurations are provided for using qgis server directly with fastcgi:
+- nginx: [conf/nginx-fcgi-sample.conf](conf/nginx-fcgi-sample.conf)
+- caddy: [conf/Caddyfile-fcgi-sample](conf/Caddyfile-fcgi-sample)
 
 ## Available tags
 

--- a/server/conf/Caddyfile-fcgi-sample
+++ b/server/conf/Caddyfile-fcgi-sample
@@ -1,0 +1,39 @@
+example.com {
+    # Set this path to your site's directory.
+    root * /io/www
+
+    # Enable the static file server.
+    file_server
+
+    @ogc {
+        path_regexp ogc_matcher ^/ogc/(.*)
+    }
+
+    @ows {
+        path_regexp ows_matcher ^/ows/(.*)
+    }
+
+    @wfs3 {
+        path_regexp wfs_matcher ^/wfs3/(.*)/
+    }
+
+    reverse_proxy @ogc qgisserver:9993 {
+        transport fastcgi {
+            env QUERY_STRING {query}&map=/io/data/{http.regexp.ogc_matcher.1}.qgs
+        }
+    }
+
+    # https://localhost/ows/bees?SERVICE=WMS&REQUEST=GetCapabilities
+    reverse_proxy @ows qgisserver:9993 {
+        transport fastcgi {
+            env QUERY_STRING {query}&map=/io/data/{http.regexp.ows_matcher.1}.qgs
+        }
+    }
+
+    # https://localhost/wfs3/bees/collections
+    reverse_proxy @wfs3 qgisserver:9993 {
+        transport fastcgi {
+            env QUERY_STRING {query}&map=/io/data/{http.regexp.wfs_matcher.1}.qgs
+        }
+    }
+}


### PR DESCRIPTION
## Description
Add caddy configuration for reference

I had been using this config for quite a while using the Dockerfile at https://docs.qgis.org/3.34/en/docs/server_manual/containerized_deployment.html with no issue.

I have verified this works following the url structure https://example.com/qgis_mapserv.fcgi?SERVICE=WMTS&REQUEST=GetCapabilities&MAP=/io/data/test/test.qgz with the `ltr` tag.