### PR TITLE
Install repo twice because of debian 12 bug

### DIFF
--- a/desktop/Dockerfile
+++ b/desktop/Dockerfile
@@ -11,6 +11,7 @@ RUN apt update && apt install -y gnupg wget software-properties-common && \
     wget -qO - https://qgis.org/downloads/qgis-2022.gpg.key | gpg --no-default-keyring --keyring gnupg-ring:/etc/apt/trusted.gpg.d/qgis-archive.gpg --import && \
     chmod a+r /etc/apt/trusted.gpg.d/qgis-archive.gpg && \
     add-apt-repository "deb https://qgis.org/${os} ${release} main" && \
+    add-apt-repository "deb https://qgis.org/${os} ${release} main" && \
     apt update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y python3-pip qgis python3-qgis python3-qgis-common python3-venv \
       python3-pytest python3-mock xvfb qttools5-dev-tools && \

--- a/desktop/Dockerfile
+++ b/desktop/Dockerfile
@@ -10,7 +10,8 @@ ARG release
 RUN apt update && apt install -y gnupg wget software-properties-common && \
     wget -qO - https://qgis.org/downloads/qgis-2022.gpg.key | gpg --no-default-keyring --keyring gnupg-ring:/etc/apt/trusted.gpg.d/qgis-archive.gpg --import && \
     chmod a+r /etc/apt/trusted.gpg.d/qgis-archive.gpg && \
-    add-apt-repository "deb https://qgis.org/${os} ${release} main" && \
+    # run twice because of https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1041012
+    add-apt-repository "deb https://qgis.org/${os} ${release} main" && \ 
     add-apt-repository "deb https://qgis.org/${os} ${release} main" && \
     apt update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y python3-pip qgis python3-qgis python3-qgis-common python3-venv \


### PR DESCRIPTION
Hi, we just found out that a debian bug prevents the GHA workflow from installing the latest qgis version. All bookworm-tagged images are still using qgis `3.22`. `add-apt-repository` does not install qgis repo at first call and needs to be called twice due to a bug. This is not very pretty but shouldn't have any impact on other builds. 

Here is a description of the bug https://groups.google.com/g/linux.debian.bugs.dist/c/9OfU_d8CbTI

Also if this is merged it would be nice if all qgis images with `...bookworm...` in the tag are recreated. They need to be removed before running the GHA workflow otherwise they will still contain an outdated qgis version