### PR TITLE
bugfix: ltr image contained stable release

### DIFF
--- a/scripts/build-push-docker.sh
+++ b/scripts/build-push-docker.sh
@@ -45,5 +45,5 @@ for TAG in ${TAGS}; do
   ALL_TAGS="${ALL_TAGS} --tag qgis/${REPO}:${TAG}"
 done
 
-docker buildx build --push --platform linux/amd64,linux/arm64 --build-arg os=${OS} --build-arg release=${OS_RELEASE} --build-arg repo=${QGIS_PPA}  ${ALL_TAGS} ${QGIS_TYPE}
+docker buildx build --push --platform linux/amd64,linux/arm64 --build-arg os=${QGIS_PPA} --build-arg release=${OS_RELEASE} --build-arg repo=${QGIS_PPA}  ${ALL_TAGS} ${QGIS_TYPE}
 


### PR DESCRIPTION
As mentioned in https://github.com/qgis/qgis-docker/issues/109#issuecomment-2136924314 the latest LTR images (tags: 3.34, ltr) are using the STABLE version of qgis not LTR. They should be removed and workflow should be retriggered. Following images are affected:

```
ltr-focal
3.34.7-jammy
3.34-jammy
ltr-jammy
3.34.7-bookworm
3.34-bookworm
ltr-bookworm
3.34.7-noble
3.34.7
3.34-noble
ltr-noble
3.34
ltr
```